### PR TITLE
Fix dataset pipeline: sort order, dominance, PCI status, LVP/PDA

### DIFF
--- a/dataset_creation/generate_dataset.py
+++ b/dataset_creation/generate_dataset.py
@@ -74,7 +74,6 @@ NON_RCA_VESSELS = [
     "om1_stenosis", "om2_stenosis", "bx_stenosis", "lvp_stenosis"
 ]
 RIGHT_DOMINANCE_DEPENDENT_VESSELS = ["pda_stenosis", "posterolateral_stenosis"]
-LEFT_DOMINANCE_DEPENDENT_VESSELS = ["pda_stenosis"]
 
 # ──────────────────────────────────────────────────────────────────────────
 # Formatting Functions
@@ -322,6 +321,10 @@ def _study_has_pci_on_side(df: pd.DataFrame) -> pd.Series:
     """Return a boolean Series: True when the GT *_pcidone columns confirm
     that a PCI was actually performed on the video's coronary side.
 
+    For non-LCA/RCA rows (e.g. "Femoral", "Other", "Catheter") we return
+    True so that stent=1 on those rows still triggers PCI status (legacy
+    behaviour).  These rows are filtered out before inference anyway.
+
     If no *_pcidone columns are present, falls back to True (trust the
     stent_presence_class classifier as before).
     """
@@ -329,17 +332,15 @@ def _study_has_pci_on_side(df: pd.DataFrame) -> pd.Series:
     rca_cols = [c for c in _RCA_PCIDONE_COLS if c in df.columns]
 
     if not lca_cols and not rca_cols:
-        # No GT available — fall back to stent_presence_class
         return pd.Series(True, index=df.index)
 
-    # Per-row: does the study have any pcidone > 0 for this video's side?
     lca_any = (df[lca_cols].apply(pd.to_numeric, errors="coerce").fillna(0) > 0).any(axis=1) if lca_cols else pd.Series(False, index=df.index)
     rca_any = (df[rca_cols].apply(pd.to_numeric, errors="coerce").fillna(0) > 0).any(axis=1) if rca_cols else pd.Series(False, index=df.index)
 
-    is_left = df["main_structure_name"] == "Left Coronary"
-    is_right = df["main_structure_name"] == "Right Coronary"
+    is_left = df["main_structure_name"].eq("Left Coronary")
+    is_right = df["main_structure_name"].eq("Right Coronary")
 
-    # True when the GT says PCI happened on this video's artery side
+    # LCA/RCA → check GT pcidone on that side; everything else → True (legacy)
     return (is_left & lca_any) | (is_right & rca_any) | (~is_left & ~is_right)
 
 
@@ -579,6 +580,47 @@ def _extract_acq_time_from_filename(fn: str) -> Optional[float]:
     return None
 
 
+def sort_by_study_and_time(df: pd.DataFrame) -> pd.DataFrame:
+    """Sort DataFrame by StudyInstanceUID and acquisition time.
+
+    The most reliable time source is the DICOM acquisition timestamp
+    embedded in the SOP Instance UID portion of the filename (YYYYMMDDHHMMSS).
+    series_time / SeriesTime is used as a fallback for videos without a
+    filename timestamp.  If FileName is absent entirely, we fall back to
+    series_time / SeriesTime alone.
+
+    Returns the sorted DataFrame (temp columns are dropped).
+    """
+    if "StudyInstanceUID" not in df.columns:
+        logger.warning("No StudyInstanceUID column — skipping temporal sort")
+        return df
+
+    # Primary: acquisition time from filename
+    if "FileName" in df.columns:
+        df["_acq_time"] = df["FileName"].apply(_extract_acq_time_from_filename)
+        acq_coverage = df["_acq_time"].notna().sum()
+        logger.info("Extracted acquisition time from filenames: %d / %d (%.1f%%)",
+                     acq_coverage, len(df), 100.0 * acq_coverage / len(df))
+    else:
+        df["_acq_time"] = np.nan
+        logger.info("No FileName column — using series_time/SeriesTime only")
+
+    # Fallback: series_time / SeriesTime
+    if "series_time" in df.columns:
+        fallback = pd.to_numeric(df["series_time"], errors="coerce")
+        fallback = fallback.where(fallback > 0)  # -1 means missing
+    elif "SeriesTime" in df.columns:
+        fallback = pd.to_numeric(df["SeriesTime"], errors="coerce")
+    else:
+        fallback = pd.Series(np.nan, index=df.index)
+
+    df["_sort_time"] = df["_acq_time"].fillna(fallback)
+    df = df.sort_values(["StudyInstanceUID", "_sort_time"], na_position="last")
+    df.drop(columns=["_acq_time", "_sort_time"], inplace=True)
+    logger.info("Sorted data by StudyInstanceUID and acquisition time")
+    return df
+
+
 def process_dataset(
     input_path: str,
     output_dir: str,
@@ -586,7 +628,7 @@ def process_dataset(
 ) -> None:
     """
     Main dataset processing pipeline.
-    
+
     Args:
         input_path: Path to input data file
         output_dir: Directory to save processed data
@@ -595,43 +637,18 @@ def process_dataset(
     # Create output directory
     output_path = Path(output_dir)
     output_path.mkdir(parents=True, exist_ok=True)
-    
+
     # Load data
     df = load_data(input_path)
-    
+
     # Apply mapping if needed
     if 'apply_mappings' in config and config['apply_mappings']:
         if 'main_structure_class' in df.columns:
             df['main_structure_name'] = df['main_structure_class'].map(MAIN_STRUCTURE_MAP)
         if 'dominance_class' in df.columns:
             df['dominance_name'] = df['dominance_class'].map(DOMINANCE_MAP)
-        
-        # Sort by StudyInstanceUID and acquisition time for proper temporal ordering.
-        # The most reliable time source is the DICOM acquisition timestamp embedded
-        # in the SOP Instance UID portion of the filename (YYYYMMDDHHMMSS pattern).
-        # series_time can be a transfer/storage time with corrupted values that break
-        # sort order within a study, so we only use it as a fallback.
-        if 'StudyInstanceUID' in df.columns and 'FileName' in df.columns:
-            df['_acq_time'] = df['FileName'].apply(_extract_acq_time_from_filename)
-            acq_coverage = df['_acq_time'].notna().sum()
-            logger.info("Extracted acquisition time from filenames: %d / %d (%.1f%%)",
-                        acq_coverage, len(df), 100.0 * acq_coverage / len(df))
 
-            # Fallback to series_time / SeriesTime for videos without filename timestamps
-            if 'series_time' in df.columns:
-                fallback = pd.to_numeric(df['series_time'], errors='coerce')
-                fallback = fallback.where(fallback > 0)  # -1 means missing
-            elif 'SeriesTime' in df.columns:
-                fallback = pd.to_numeric(df['SeriesTime'], errors='coerce')
-            else:
-                fallback = pd.Series(np.nan, index=df.index)
-
-            df['_sort_time'] = df['_acq_time'].fillna(fallback)
-            df = df.sort_values(['StudyInstanceUID', '_sort_time'], na_position='last')
-            df.drop(columns=['_acq_time', '_sort_time'], inplace=True)
-            logger.info("Sorted data by StudyInstanceUID and acquisition time")
-        elif 'StudyInstanceUID' in df.columns:
-            logger.warning("No FileName column — cannot extract acquisition time")
+        df = sort_by_study_and_time(df)
     
     # Assign procedure status based on PCI timing (if enabled and required columns exist)
     if config.get('assign_status', True):

--- a/scripts/regenerate_dataset.py
+++ b/scripts/regenerate_dataset.py
@@ -2,12 +2,19 @@
 """
 Regenerate Dataset with Bug Fixes
 
-Applies three fixes to the dataset pipeline:
-1. SeriesTime sort bug: Use series_time (int64, full coverage) instead of
-   SeriesTime (float64, ~86% NaN) for temporal ordering.
-2. Dominance override: If lvp_stenosis > 0, force left-dominant regardless of label.
-3. LVP/PDA mutual exclusivity: In left-dominant hearts exclude PDA (LVP ≡ PDA);
-   in right-dominant hearts exclude LVP.
+Applies the following fixes to the dataset pipeline:
+1. Acquisition-time sort: Use DICOM timestamps from SOP UIDs in filenames
+   (YYYYMMDDHHMMSS) for correct temporal ordering, including procedures
+   that span midnight.  Falls back to series_time / SeriesTime.
+2. PCI cascade gating: stent_presence_class=1 → always PCI, but the
+   POST_PCI cascade only triggers when GT *_pcidone confirms PCI on the
+   labelled coronary side.
+3. Dominance override: If lvp_stenosis > 0, force left-dominant regardless
+   of the dominance label.
+4. LVP/PDA mutual exclusivity: In left-dominant hearts exclude PDA
+   (LVP ≡ PDA); in right-dominant hearts exclude LVP.
+5. Congenital exclusion: Filter out congenital-procedure studies and
+   studies with all stenosis = -1/NaN from inference.
 
 Outputs:
   - Updated parquet with corrected status assignments
@@ -29,7 +36,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from dataset_creation.generate_dataset import (
     assign_procedure_status,
     create_report,
-    _extract_acq_time_from_filename,
+    sort_by_study_and_time,
     MAIN_STRUCTURE_MAP,
     DOMINANCE_MAP,
 )
@@ -64,35 +71,15 @@ def main():
     if "dominance_class" in df.columns:
         df["dominance_name"] = df["dominance_class"].map(DOMINANCE_MAP)
 
-    # ── 3. Sort by acquisition time from filename (FIX #1) ──────────────────
-    # The DICOM acquisition timestamp embedded in SOP Instance UIDs is the most
-    # reliable time source.  series_time can be a transfer/storage timestamp
-    # with corrupted hour values that break sort order within a study.
-    logger.info("Extracting acquisition time from filenames...")
-    df["_acq_time"] = df["FileName"].apply(_extract_acq_time_from_filename)
-    acq_coverage = df["_acq_time"].notna().sum()
-    logger.info("Filename acq_time: %d / %d (%.1f%%)",
-                acq_coverage, len(df), 100.0 * acq_coverage / len(df))
-
-    # Fallback to series_time for videos without filename timestamps
-    if "series_time" in df.columns:
-        fallback = pd.to_numeric(df["series_time"], errors="coerce")
-        fallback = fallback.where(fallback > 0)
-    elif "SeriesTime" in df.columns:
-        fallback = pd.to_numeric(df["SeriesTime"], errors="coerce")
-    else:
-        fallback = pd.Series(np.nan, index=df.index)
-
-    df["_sort_time"] = df["_acq_time"].fillna(fallback)
-    df = df.sort_values(["StudyInstanceUID", "_sort_time"], na_position="last")
-    df.drop(columns=["_acq_time", "_sort_time"], inplace=True)
-    logger.info("Sorted by StudyInstanceUID + acquisition time")
+    # ── 3. Sort by acquisition time (shared helper) ──────────────────────────
+    df = sort_by_study_and_time(df)
 
     # ── 4. Re-assign status ──────────────────────────────────────────────────
     df = assign_procedure_status(df)
 
     if old_status is not None:
-        changed = (df["status"].values != old_status.values).sum()
+        # Use index-aligned comparison (not .values) so row reordering is safe
+        changed = (df["status"] != old_status.reindex(df.index)).sum()
         logger.info("Status changes vs original: %d / %d (%.2f%%)",
                      changed, len(df), 100.0 * changed / len(df))
 
@@ -132,7 +119,7 @@ def main():
     df_diag["Split"] = df_diag["Split"].replace({"test": "inference"})
     logger.info("Split distribution:\n%s", df_diag["Split"].value_counts())
 
-    # ── 8. Generate reports (FIX #2 + #3: dominance override + LVP/PDA) ─────
+    # ── 8. Generate reports (dominance override + LVP/PDA) ───────────────────
     logger.info("Generating reports for %d diagnostic videos...", len(df_diag))
     df_diag["Report"] = df_diag.progress_apply(
         lambda r: create_report(r, coronary_specific_report=True), axis=1


### PR DESCRIPTION
## Summary
- **Sort order**: Use DICOM acquisition time from filename SOP UIDs instead of `series_time`/`SeriesTime` which can be corrupted transfer timestamps (54.5% of studies had wrong sort order)
- **Dominance override**: `lvp_stenosis > 0` forces left-dominant regardless of dominance label (218/253 studies were mislabeled as right-dominant)
- **LVP/PDA mutual exclusivity**: Left-dominant hearts use LVP (≡ PDA) so PDA is excluded from reports; right-dominant hearts exclude LVP
- **PCI status with stent gating**: `stent_presence_class=1` always marks a video as PCI, but the POST_PCI cascade only triggers when GT `*_pcidone` confirms PCI on that coronary side — prevents misclassified-side videos from contaminating diagnostic labels on neighbouring videos
- **Groupby shift fix**: `.shift()` now inside `.transform()` to prevent PCI state leaking across `(StudyInstanceUID, main_structure_name)` group boundaries (~16K videos were wrongly labeled POST_PCI)
- **LEFT_DOMINANCE_DEPENDENT_VESSELS**: Removed duplicate `lvp_stenosis` (already in `NON_RCA_VESSELS`)

## Files changed
- `dataset_creation/generate_dataset.py` — all 6 fixes
- `scripts/regenerate_dataset.py` — new regeneration script for applying fixes to existing parquet

## Test plan
- [x] Verified study 5176078 (RCA PCI only): 5 LCA diagnostic videos preserved, stent=1 LCA videos excluded without cascading POST_PCI
- [x] Verified dominance override: 253 studies with lvp>0, 218 correctly relabeled left-dominant
- [x] Compared 4 studies (2 changed, 2 unchanged) with visual video inspection
- [x] Regenerated full inference CSV: 203,955 rows across 32,403 studies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect core dataset labeling (status assignment), temporal ordering, and which rows are included for inference, so downstream training/inference splits and metrics may shift substantially despite being deterministic bug fixes.
> 
> **Overview**
> Improves dataset generation correctness by sorting videos within each study using acquisition timestamps parsed from filename SOP UIDs (with fallback to `series_time`/`SeriesTime`), reducing mis-ordered procedure sequences.
> 
> Refines labeling and reporting logic: `stent_presence_class=1` always marks that video as `PCI`, but `POST_PCI` only cascades when side-matched GT `*_pcidone` confirms PCI, and the groupwise `cumsum().shift()` is scoped correctly per `(StudyInstanceUID, main_structure_name)`. Reporting now forces *left dominance* when `lvp_stenosis>0` and makes LVP/PDA mutually exclusive by excluding `lvp_stenosis` from right-dominant non-RCA vessels.
> 
> Tightens inference filtering by excluding congenital-procedure series (`series_description` contains "CONGENITAL") and rows with no usable stenosis data (all `*_stenosis` are `-1`/NaN). Adds `scripts/regenerate_dataset.py` to reprocess an existing parquet with these fixes and regenerate the diagnostic-only inference CSV and reports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4b15d089a23bf70fefcb64eb22d9b4453210b17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Summary by Sourcery

Fix dataset generation to use reliable acquisition time for temporal ordering, correct coronary dominance and LVP/PDA handling, and tighten PCI/POST_PCI status assignment logic, plus add a script to regenerate the dataset with these fixes.

Bug Fixes:
- Correct left-dominant vessel configuration so LVP and PDA are not double-counted.
- Override dominance to left-dominant when LVP stenosis is present and ensure LVP/PDA are mutually exclusive in reports.
- Prevent POST_PCI status from leaking across study and artery boundaries by scoping the PCI cascade per (StudyInstanceUID, main_structure_name).
- Restrict POST_PCI cascading to cases where ground-truth *_pcidone confirms PCI on the same coronary side while still marking all stent=1 videos as PCI.
- Fix temporal sorting within studies by preferring acquisition time parsed from filenames and only falling back to series_time/SeriesTime when needed.

Enhancements:
- Introduce side-aware PCI detection helper based on grouped *_pcidone columns to support more accurate procedure status labeling.
- Add a standalone regeneration script to reload the existing parquet, re-sort, reassign status, and regenerate diagnostic inference CSVs with corrected reports.